### PR TITLE
Fix focus update to happen before the image is rendered

### DIFF
--- a/Assets/PostProcessing/Utilities/FocusPuller.cs
+++ b/Assets/PostProcessing/Utilities/FocusPuller.cs
@@ -52,7 +52,7 @@ namespace UnityEngine.PostProcessing.Utilities
             speed = _speed;
         }
 
-        void Update()
+        void OnPreRender()
         {
             if (_target == null) return;
 


### PR DESCRIPTION
Changing the update method to OnPreRender removes a one frame delay for focussing on the current position. This is not that important, if the focus change should be delayed anyways, but can have significant mismatches for fast moving objects that should stay in focus immediately.